### PR TITLE
Adjust permissions for release drafter and clean up release types

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,7 +13,6 @@ on:
   release:
     types:
       - published
-      - released
   workflow_run:
     workflows: ["CI"]
     branches: [main]

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -11,7 +11,7 @@ jobs:
   update_release_draft:
     name: ✏️ Draft release
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Update permissions for the release drafter to allow writing and remove the redundant release type.