### PR TITLE
Specify versions for requests and paho-mqtt in requirements.txt

### DIFF
--- a/snapmaker-monitor/requirements.txt
+++ b/snapmaker-monitor/requirements.txt
@@ -1,2 +1,2 @@
-requests
-paho-mqtt
+requests==2.32.4
+paho-mqtt==2.1.0


### PR DESCRIPTION
Define specific versions for the requests and paho-mqtt libraries to ensure compatibility and stability.