### PR TITLE
Update Home Assistant integration configuration defaults

### DIFF
--- a/snapmaker-monitor/config.yaml
+++ b/snapmaker-monitor/config.yaml
@@ -6,22 +6,23 @@ description: Python script to monitor Snapmaker 2.0 printer status and send upda
 url: https://github.com/NRE-Com-Net/hassio-addon-snapmaker-monitor
 codenotary: nemesissre@gmail.com
 boot: manual_only
+homeassistant_api: true
 init: false
 arch:
   - aarch64
   - amd64
   - armv7
 options:
-  ha_token: null
-  ha_webhook_url: null
+  ha_token: ""
+  ha_webhook_url: ""
   sm_ip: null
   sm_port: 8080
   log_level: info
-  mqtt_broker: null
+  mqtt_broker: ""
   mqtt_port: 1883
   mqtt_topic: snapmaker/status
-  mqtt_user: null
-  mqtt_password: null
+  mqtt_user: ""
+  mqtt_password: ""
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   ha_token: str?


### PR DESCRIPTION
Adjust configuration defaults for the Home Assistant integration to ensure only the mandatory option, `sm_ip`, is required, while other options are set to empty strings.