### PR TITLE
Update configuration to use Supervisor API

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,8 @@ permissions:
 # yamllint disable-line rule:truthy
 on:
   push:
+    branches:
+      - main
   pull_request:
     types:
       - opened

--- a/.yamllint
+++ b/.yamllint
@@ -50,7 +50,7 @@ rules:
     level: error
   line-length:
     level: warning
-    max: 120
+    max: 180
     allow-non-breakable-words: true
     allow-non-breakable-inline-mappings: true
   new-line-at-end-of-file:

--- a/snapmaker-monitor/config.yaml
+++ b/snapmaker-monitor/config.yaml
@@ -13,11 +13,10 @@ arch:
   - amd64
   - armv7
 options:
-  ha_token: ""
-  ha_webhook_url: ""
+  log_level: info
+  ha_webhook_id: ""
   sm_ip: null
   sm_port: 8080
-  log_level: info
   mqtt_broker: ""
   mqtt_port: 1883
   mqtt_topic: snapmaker/status
@@ -25,8 +24,7 @@ options:
   mqtt_password: ""
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
-  ha_token: str?
-  ha_webhook_url: str?
+  ha_webhook_id: str?
   sm_ip: str
   sm_port: int(1,65535)?
   mqtt_broker: str?

--- a/snapmaker-monitor/rootfs/app/smStatus.py
+++ b/snapmaker-monitor/rootfs/app/smStatus.py
@@ -35,8 +35,12 @@ MQTT_PORT = int(os.environ.get("MQTT_PORT", '1883'))
 MQTT_TOPIC = os.environ.get("MQTT_TOPIC", 'snapmaker/status')
 MQTT_USER = os.environ.get("MQTT_USER", '')
 MQTT_PASSWORD = os.environ.get("MQTT_PASSWORD", '')
-HA_TOKEN = os.environ.get("HA_TOKEN", '')  # Set your HomeAssistant API Token
-HA_WEBHOOK_URL = os.environ.get("HA_WEBHOOK_URL", '')  # Set your HomeAssistant WebHook URL
+HA_TOKEN = os.environ.get("SUPERVISOR_TOKEN", '')  # Set your HomeAssistant API Token
+if os.path.exists("/.dockerenv"):
+  HA_WEBHOOK_ID = os.environ.get("HA_WEBHOOK_ID")  # HomeAssistant WebHook ID
+  HA_WEBHOOK_URL = "http://supervisor/core/api/webhook/" + HA_WEBHOOK_ID
+else:
+  HA_WEBHOOK_URL = os.environ.get("HA_WEBHOOK_URL", '')  # Set your HomeAssistant WebHook URL
 CONNECT_IP = os.environ.get("SM_IP", '')  # Set your SnapMaker IP or let it discover
 CONNECT_PORT = os.environ.get("SM_PORT", '8080')  # Set your SnapMaker API Port (default is 8080)
 if os.path.exists("/.dockerenv"):

--- a/snapmaker-monitor/rootfs/app/smStatus.py
+++ b/snapmaker-monitor/rootfs/app/smStatus.py
@@ -36,14 +36,18 @@ MQTT_TOPIC = os.environ.get("MQTT_TOPIC", 'snapmaker/status')
 MQTT_USER = os.environ.get("MQTT_USER", '')
 MQTT_PASSWORD = os.environ.get("MQTT_PASSWORD", '')
 HA_TOKEN = os.environ.get("SUPERVISOR_TOKEN", '')  # Set your HomeAssistant API Token
-if os.path.exists("/.dockerenv"):
+if os.path.exists("/data/options.json"):
   HA_WEBHOOK_ID = os.environ.get("HA_WEBHOOK_ID")  # HomeAssistant WebHook ID
-  HA_WEBHOOK_URL = "http://supervisor/core/api/webhook/" + HA_WEBHOOK_ID
+  if HA_WEBHOOK_ID is not None:
+    HA_WEBHOOK_URL = "http://supervisor/core/api/webhook/" + HA_WEBHOOK_ID
+  else:
+    logging.error("HA_WEBHOOK_ID environment variable is not set. HA_WEBHOOK_URL will be empty.")
+    HA_WEBHOOK_URL = ''
 else:
   HA_WEBHOOK_URL = os.environ.get("HA_WEBHOOK_URL", '')  # Set your HomeAssistant WebHook URL
 CONNECT_IP = os.environ.get("SM_IP", '')  # Set your SnapMaker IP or let it discover
 CONNECT_PORT = os.environ.get("SM_PORT", '8080')  # Set your SnapMaker API Port (default is 8080)
-if os.path.exists("/.dockerenv"):
+if os.path.exists("/data/options.json"):
   TOKEN_FILE = os.path.join("/data", "SMtoken.txt")  # inside Docker
 else:
   TOKEN_FILE = os.path.join(os.getcwd(), "SMtoken.txt")  # not in Docker
@@ -270,9 +274,9 @@ def updDiscover():
 
 # Run Main Program
 if __name__ == "__main__":
-  # Check if running inside a Docker container
-  if os.path.exists("/.dockerenv"):
-    logging.debug("Running inside a Docker container")
+  # Check if running inside a HA Addon container
+  if os.path.exists("/data/options.json"):
+    logging.debug("Running inside a HA Addon container")
     while True:
       try:
         main()
@@ -281,6 +285,6 @@ if __name__ == "__main__":
         logging.error(f"An error occurred: {e}")
         time.sleep(60)
   else:
-    logging.debug("Not running inside a Docker container")
+    logging.debug("Not running inside a HA Addon container")
     main()
     sys.exit(0)

--- a/snapmaker-monitor/rootfs/etc/s6-overlay/s6-rc.d/smMonitor/run
+++ b/snapmaker-monitor/rootfs/etc/s6-overlay/s6-rc.d/smMonitor/run
@@ -12,14 +12,9 @@ if bashio::config.has_value 'log_level'; then
     export LOG_LEVEL=${log_level}
 fi
 
-if bashio::config.has_value 'ha_token'; then
-    ha_token=$(bashio::config 'ha_token')
-    export HA_TOKEN=${ha_token}
-fi
-
-if bashio::config.has_value 'ha_webhook_url'; then
-    ha_webhook_url=$(bashio::config 'ha_webhook_url')
-    export HA_WEBHOOK_URL=${ha_webhook_url}
+if bashio::config.has_value 'ha_webhook_id'; then
+    ha_webhook_id=$(bashio::config 'ha_webhook_id')
+    export HA_WEBHOOK_ID=${ha_webhook_id}
 fi
 
 if bashio::config.has_value 'sm_ip'; then


### PR DESCRIPTION
Revise the configuration to utilize the Supervisor API by replacing the Home Assistant token and webhook URL with a webhook ID. Adjustments ensure compatibility with the Supervisor environment.